### PR TITLE
Modify ping_mbulk to ping_bulk in benchmark.c

### DIFF
--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1827,9 +1827,9 @@ int main(int argc, const char **argv) {
         if (test_is_selected("ping_inline") || test_is_selected("ping"))
             benchmark("PING_INLINE","PING\r\n",6);
 
-        if (test_is_selected("ping_bulk") || test_is_selected("ping")) {
+        if (test_is_selected("ping_mbulk") || test_is_selected("ping")) {
             len = redisFormatCommand(&cmd,"PING");
-            benchmark("PING_BULK",cmd,len);
+            benchmark("PING_MBULK",cmd,len);
             free(cmd);
         }
 

--- a/src/redis-benchmark.c
+++ b/src/redis-benchmark.c
@@ -1827,7 +1827,7 @@ int main(int argc, const char **argv) {
         if (test_is_selected("ping_inline") || test_is_selected("ping"))
             benchmark("PING_INLINE","PING\r\n",6);
 
-        if (test_is_selected("ping_mbulk") || test_is_selected("ping")) {
+        if (test_is_selected("ping_bulk") || test_is_selected("ping")) {
             len = redisFormatCommand(&cmd,"PING");
             benchmark("PING_BULK",cmd,len);
             free(cmd);

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -33,7 +33,7 @@ start_server {tags {"benchmark"}} {
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
                 fail "redis-benchmark non zero code. first line: $first_line"
             }
-            # ping total calls are 2*issued commands per test due to PING_INLINE and PING_BULK
+            # ping total calls are 2*issued commands per test due to PING_INLINE and PING_MBULK
             assert_match  {*calls=200,*} [cmdstat ping]
             assert_match  {*calls=100,*} [cmdstat set]
             assert_match  {*calls=100,*} [cmdstat get]


### PR DESCRIPTION
As described in redis-benchamrk help message 'The test names are the same as the ones produced as output.', In redis-benchmark output, we can only see PING_BULK, but the cmd `redis-benchmark -t ping_bulk` is not supported. We  have to run it with ping_mbulk which is not user friendly.